### PR TITLE
v1.2 regression: Fix Syntax Error on Node.js v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Mocha = require('mocha');
 const seedrandom = require('seedrandom');
 const color = require('chalk');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 const Mocha = require('mocha');
 const seedrandom = require('seedrandom');


### PR DESCRIPTION
Use of block-scoped declarations (let, const, etc.) without strict mode enabled leads to a syntax error in Node.js v4:

````
/Users/jhecking/aerospike/aerospike-client-nodejs/node_modules/choma/index.js:28
  let index = -1;
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
````

This issue first started appearing in v1.2 and was introduced in 36770c0fec2126acbeb9121c70496a7b1d73c8cd I believe.

Note sure if support for Node.js v4 is a priority for choma. But I use choma in my own [project](https://github.com/aerospike/aerospike-client-nodejs) which unfortunately still needs to support Node.js v4 for now.